### PR TITLE
Update to work with App Transport Security of iOS9

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -36,5 +36,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes this iOS9 issue.
![simulator screen shot oct 3 2015 5 21 42 pm](https://cloud.githubusercontent.com/assets/997157/10265365/42f69cf4-69f3-11e5-90c2-3ded89fc1852.png)
