### PR TITLE
stringify res from github before putting contents into a text element

### DIFF
--- a/App/Components/Dashboard.js
+++ b/App/Components/Dashboard.js
@@ -26,7 +26,7 @@ render(){
   return (
       <View style={styles.container}>
         <Text> This is the dashboard </Text>
-        <Text> {this.props.userInfo} </Text>
+        <Text> {JSON.stringify(this.props.userInfo)} </Text>
       </View>
     )
 }


### PR DESCRIPTION
When I did the exercise as shown in the video and in your current code I got an error because what is returned when the promise form res.json() is resolved is still an object and the Text element didn't like being fed an object. 

<img width="316" alt="screen shot 2016-03-23 at 3 48 50 pm" src="https://cloud.githubusercontent.com/assets/7663672/14000340/d6404b2a-f10e-11e5-997d-1a0fe2b9d844.png">

wrapping it in JSON.stringify() fixed the issue.
