### PR TITLE
Fixing typo in ActivityIndicatorIOS size

### DIFF
--- a/App/Components/Main.js
+++ b/App/Components/Main.js
@@ -115,7 +115,7 @@ class Main extends React.Component{
         <ActivityIndicatorIOS
           animating={this.state.isLoading}
           color="#111"
-          size="Large"></ActivityIndicatorIOS>
+          size="large"></ActivityIndicatorIOS>
         {showErr}
       </View>
       )


### PR DESCRIPTION
Thanks for awesome work.

This PR is fixing a minor typo in lesson 7 for using ActivityIndicatorIOS. 
`size` property accepts only `small` and `large`
