### PR TITLE
Fix typo in Main component.

### DIFF
--- a/App/Components/Main.js
+++ b/App/Components/Main.js
@@ -115,7 +115,7 @@ class Main extends React.Component{
         <ActivityIndicatorIOS
           animating={this.state.isLoading}
           color="#111"
-          size="Large"></ActivityIndicatorIOS>
+          size="large"></ActivityIndicatorIOS>
         {showErr}
       </View>
       )


### PR DESCRIPTION
Hey guys,
The `size` attribute of `ActivityIndicatorIOS` throws an error due to a typo. I've fixed it here.
Cheers

Reference: https://facebook.github.io/react-native/docs/activityindicatorios.html#size
