### PR TITLE
Replace deprecated url prop in WebView with source

### DIFF
--- a/App/Components/Helpers/WebView.js
+++ b/App/Components/Helpers/WebView.js
@@ -18,7 +18,7 @@ class Web extends React.Component{
   render() {
     return (
       <View style={styles.container}>
-        <WebView url={this.props.url}/>
+        <WebView source={{uri: this.props.url}} />
       </View>
     );
   }


### PR DESCRIPTION
Hey guys,
The `url` prop in `WebView` is deprecated. I've updated it here to the recommended `source` prop.
Cheers

Reference: https://facebook.github.io/react-native/docs/webview.html#url
