### PR TITLE
[fix] enableEmptySections in ListView in Notes component

### DIFF
--- a/App/Components/Notes.js
+++ b/App/Components/Notes.js
@@ -110,6 +110,7 @@ class Notes extends React.Component{
     return (
       <View style={styles.container}>
           <ListView
+            enableEmptSections={true}
             dataSource={this.state.dataSource}
             renderRow={this.renderRow}
             renderHeader={() => <Badge userInfo={this.props.userInfo}/>} />


### PR DESCRIPTION
Enables empty sections property in ListView to prevent 'In next release empty section headers will be rendered' error from displaying.
